### PR TITLE
Add user id to local storage.  Do profile lookup on page load.

### DIFF
--- a/client/src/containers/Home.jsx
+++ b/client/src/containers/Home.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import axios from 'axios';
 import * as Actions from '../store/actions';
 
 class Home extends React.Component {
@@ -12,7 +13,18 @@ class Home extends React.Component {
     if (!this.props.appState.loggedIn) {
       const token = window.localStorage.getItem('authToken');
       if (token && token !== 'undefined') {
-        this.props.actions.login(token);
+        const user = window.localStorage.getItem('userId');
+        axios.get(`https://co-ment.glith.me/api/profile/${user}`, {
+          headers: {
+            Authorization: `Bearer ${this.props.appState.authToken}`,
+          },
+        })
+        .then((response) => {
+          this.props.actions.login(response.data.token, response.data.profile);
+        })
+        .catch((error) => {
+          this.props.actions.logout();
+        });
       }
     }
   }

--- a/client/src/containers/Login.jsx
+++ b/client/src/containers/Login.jsx
@@ -23,7 +23,7 @@ class Login extends React.Component {
     if (username && password) {
       axios.post('https://co-ment.glitch.me/api/login', { username, password })
         .then((result) => {
-          console.log(typeof result.data.token)
+          console.log(result.data);
           this.props.actions.login(result.data.token, result.data.profile);
           this.props.actions.clearLoginPwd();
           this.props.history.push('/');

--- a/client/src/store/reducers/appState.js
+++ b/client/src/store/reducers/appState.js
@@ -10,8 +10,8 @@ const INITIAL_STATE = {
 function appState(state = INITIAL_STATE, action) {
   switch (action.type) {
     case LOGIN: {
-      console.log(typeof action.token);
       window.localStorage.setItem('authToken', JSON.stringify(action.token));
+      window.localStorage.setItem('userId', JSON.stringify(action.profile._id));
       const newState = update(state,
         { profile: { $set: action.profile },
           authToken: { $set: action.token },
@@ -23,6 +23,7 @@ function appState(state = INITIAL_STATE, action) {
 
     case LOGOUT:
       window.localStorage.removeItem('authToken');
+      window.localStorage.removeItem('userId');
       return Object.assign({}, state, { loggedIn: false, authToken: {} });
     default:
       return state;


### PR DESCRIPTION
UserId now saved in local storage.  When page first loads, it will look for an authToken/userId in storage and attempt to find the profile.  On success, it will update state to logged in and save the profile.  On failure it will perform a logout which deletes the storage items.