### PR TITLE
The proptype error msg fix is backed out.  It killed webpack on restart.

### DIFF
--- a/client/src/containers/Home.jsx
+++ b/client/src/containers/Home.jsx
@@ -73,16 +73,6 @@ class Home extends React.Component {
   }
 }
 
-Home.propTypes = {
-  actions: PropTypes.Object(PropTypes.shape({
-    login: PropTypes.function.isRequired,
-    logout: PropTypes.function.isRequired,
-  })).isRequired,
-  appState: PropTypes.Object(PropTypes.shape({
-    loggedIn: PropTypes.boolean.isRequired,
-  })).isRequired,
-};
-
 const mapStateToProps = state => ({
   appState: state.appState,
 });


### PR DESCRIPTION
Backing out part of the last PR.  The prop-type definitions fixed eslint errors but killed webpack.  i think because those props aren't available when the component first gets created.