### PR TITLE
Adds OPTIONS CORS handler to server.js; Fixes add post route

### DIFF
--- a/routes/apiroutes.js
+++ b/routes/apiroutes.js
@@ -254,18 +254,7 @@ routes.get('/api/posts', auth, (req, res) => {
    Example: POST > `/api/posts`
 */
 routes.post('/api/posts', auth, (req, res) => {
-    
-    // build new post object from request body and token
-    const inputPost = {
-        author       : req.body.author,
-        author_id    : req.token._id,
-        role         : req.body.role,
-        title        : req.body.title,
-        body         : req.body.body,
-        keywords     : req.body.keywords,
-        availability : req.body.availability
-    };
-    
+        
     // Check if post with same author_id, role & title already exists
     Post
         .findOne({
@@ -284,9 +273,23 @@ routes.post('/api/posts', auth, (req, res) => {
                     .json({ message: 'Error - same/similar post already exists!'});
 
             } else {
+                
+                // create new post
+                const myPost = new Post();
+                
+                // build new post from request body and token
+                myPost.author       = req.body.author;
+                myPost.author_id    = req.body.author_id;
+                myPost.role         = req.body.role;
+                myPost.title        = req.body.title;
+                myPost.body         = req.body.body;
+                myPost.keywords     = req.body.keywords;
+                myPost.availability = req.body.availability;
 
                 // save new post to database
-                Post.create(inputPost, (err, newPost) => {
+                myPost.save( (err, newPost) => {
+                    if (err) { throw err; }
+                    
                     return res
                         .status(200)
                         .json({

--- a/server.js
+++ b/server.js
@@ -48,8 +48,16 @@ app.use(bodyParser.urlencoded({ extended : true }));
 
 app.use(function(req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");
+    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
     res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization");
-    next();
+    
+    // intercepts OPTIONS method
+    if ('OPTIONS' === req.method) {
+        // respond with 200
+        res.sendStatus(200);
+    } else {
+        next();
+    }
 });
 
 


### PR DESCRIPTION
Browsers that obey CORS protocol send a pre-flight OPTIONS request for all non-simple http requests. Our 'add post' POST route is a non-simple request. The fixes include checking all incoming http requests for OPTIONS methods and responding with a simple '200' status, and modifying the Mongoose logic to save the new posts.