### PR TITLE
Api/add email validate route

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -1,11 +1,11 @@
 /* ================================= SETUP ================================= */
 
-const detenv    = require('dotenv').config();
-const mongoose  = require('mongoose');
+const detenv   = require('dotenv').config();
+const mongoose = require('mongoose');
 const passportLocalMongoose = require('passport-local-mongoose');
-const jwt       = require('jsonwebtoken');
-const crypto    = require('crypto');
-const secret    = process.env.JWT_SECRET;
+const jwt      = require('jsonwebtoken');
+const crypto   = require('crypto');
+const secret   = process.env.JWT_SECRET;
 
 
 /* ================================ SCHEMA ================================= */
@@ -55,6 +55,17 @@ const userSchema = new mongoose.Schema({
         trim     : true
     },
     
+    signupKey  : {
+        key    : String,
+        ts     : String,
+        exp    : String
+    },
+    
+    validated  : {
+        type     : Boolean,
+        default  : false
+    },
+    
     pref_lang  : [String],  // array of strings
     
     certs      : [String],  // array of strings
@@ -101,8 +112,9 @@ userSchema.methods.validatePassword = function (pwd) {
 userSchema.methods.generateJWT = function () {
     
     const payload = {
-        _id      : this._id,
-        username : this.username
+        _id       : this._id,
+        username  : this.username,
+        validated : this.validated
     };
     const options = {
         expiresIn : '7d'

--- a/routes/authroutes.js
+++ b/routes/authroutes.js
@@ -1,17 +1,20 @@
 /* non-secured routes to handle user signup and login
 
-   ========================== Route Descriptions ======================
-   VERB      URL                       DESCRIPTION
-   --------------------------------------------------------------------
-   POST      /api/register             Save new user, return JWT
-   POST      /api/login                Authenticate user, return JWT
+   ========================== Route Descriptions ===========================
+   VERB      URL               DESCRIPTION
+   -------------------------------------------------------------------------
+   POST      /api/register     Save new user, email validation, return JWT
+   GET       /api/validate     Flip user model prop `validated` to true
+   POST      /api/login        Authenticate user, return JWT
 */
 
 /* ================================= SETUP ================================= */
 
-const routes   = require('express').Router();
-const User     = require('../models/user');
-const passport = require('passport');
+const routes    = require('express').Router();
+const passport  = require('passport');
+const crypto    = require('crypto');
+const mailer    = require('../utils/mailer');
+const User      = require('../models/user');
 
 
 /* =============================== UTILITIES =============================== */
@@ -34,6 +37,62 @@ function makeUserProfile(user) {
 }
 
 
+/* Generate random signup key
+ *
+ * @params    [none]
+ * @returns   [object]    [signup key]
+*/
+function makeSignupKey() {
+    const buf     = crypto.randomBytes(24);
+    const created = Date.now();
+
+    return {
+        key : buf.toString('hex'),
+        ts  : created,            // created time (in millisecond)
+        exp : created + 86400000  // expires in 1 day (86400000 ms)
+    };
+}
+
+
+/* Generate registration email validation url w/custom key
+ * Makes sure key is unique & saves to DB
+ *
+ * @params    [string]   user_id   [id of user to validate]
+ * @params    [string]   key       [custom validation key]
+ * @returns   [object]             [custom validation URL]
+*/
+function makeValidationUrl(user_id, key) {
+    const baseUrl = 'https://co-ment.glitch.me/api/validate';
+
+    return `${baseUrl}?uid=${user_id}&key=${key}`;
+
+}
+
+
+/* Dispatch new user validation email
+ *
+ * @ params   [object]   params      [map of the following params]
+ * @ params   [string]    * key      [randomly generated key]
+ * @ params   [string]    * to_email [user/recipient email address]
+ * @ params   [string]    * to_uid   [new user's _id ]
+*/
+function sendValidationEmail(params) {
+
+    const url     = makeValidationUrl(params.to_uid, params.key);
+    const subject = 'co/ment - Email verification required';
+    const body    = `Click the link below to validate your account:\n\n${url}`;
+
+    // send mail using `mailer` util
+    try {
+        mailer(params.to_email, subject, body);
+        console.log('Email validation sent successfully.');
+    } catch (err) {
+        console.log(`Error: $(err)`);
+    }
+
+}
+
+
 /* ================================ ROUTES ================================= */
 
 /* Route to handle new user signup.
@@ -42,7 +101,7 @@ function makeUserProfile(user) {
 routes.post('/api/register', (req, res) => {
 
     // fail if missing required inputs
-    if (!req.body.username || !req.body.password) {
+    if (!req.body.username || !req.body.password || !req.body.email) {
         return res
             .status(400)
             .json({ 'message': 'Please complete all required fields.' });
@@ -57,21 +116,44 @@ routes.post('/api/register', (req, res) => {
         .then( () => {
 
             // no user found, let's build a new one
-            const user = new User();
+            const newUser = new User();
 
-            user.username   = req.body.username;
-            user.hashPassword(req.body.password);
+            newUser.username   = req.body.username;
+            newUser.email      = req.body.email;
+            newUser.validated  = false;
+            newUser.signupKey  = makeSignupKey();
+            newUser.hashPassword(req.body.password);
 
-            user.save( err => {
+            return newUser;
+        })
+        .then( newUser => {
+
+            // save new user to database
+            newUser.save( (err, savedUser ) => {
                 if (err) { throw err; }
-                
+
+                // build filtered user profile for later response
                 const profile = {
-                    username : user.username,
-                    _id      : user._id
+                    username  : savedUser.username,
+                    email     : savedUser.email,
+                    validated : savedUser.validated,
+                    _id       : savedUser._id
                 };
 
-                // generate token, respond with profile & JWT
-                const token = user.generateJWT();
+                // build email parameter map
+                const emailParams = {
+                    key      : savedUser.signupKey.key,
+                    to_email : savedUser.email,
+                    to_uid   : savedUser._id
+                };
+
+                // send validation email, passing email param map
+                sendValidationEmail(emailParams);
+
+                // generate auth token
+                const token = savedUser.generateJWT();
+
+                // respond with profile & JWT
                 return res
                     .status(200)
                     .json({
@@ -87,6 +169,56 @@ routes.post('/api/register', (req, res) => {
                 .status(400)
                 .json({ message: err});
         });
+
+});
+
+
+/* Route to toggle user's `validated` property to `true`.
+   Returns ///
+*/
+routes.get('/api/validate', (req, res) => {
+
+    const user_id  = req.query.uid;
+    const test_key = req.query.key;
+
+    const target = {
+        _id : user_id
+    };
+
+    const updates = {
+        validated: true
+    };
+
+    User.findOneAndUpdate(target, updates)
+        .exec()
+        .then( user => {
+
+        if (!user) {
+
+            return res
+                .status(404)
+                .json({ message: 'No user with that ID found.' });
+
+        } else if (user.signupKey.key !== test_key) {
+
+            return res
+                .status(400)
+                .json({ message: 'Registration key mismatch.' });
+
+        } else {
+
+            return res
+                // status 302 = “Found"
+                .redirect(302, '/');  // you made it, go home!
+
+        }
+    })
+    .catch( err => {
+        console.log('Error!!!', err);
+            return res
+                .status(400)
+                .json({ message: err});
+    });
 
 });
 
@@ -113,7 +245,7 @@ routes.post('/api/login', (req, res, next) => {
                 .json(info);
 
         } else {
-            
+
             const profile = makeUserProfile(user._doc);
 
             // generate token, respond with profile & JWT


### PR DESCRIPTION
_updates to user model:_
Adds `signupKey` and `validated` properties to user model. `validated` defaults to _false_ and is flipped only after email validation success.
Also adds `validated` to the JWT payload in `userSchema.methods.generateJWT`.

_updates to auth routes:_
Adds a 'validate' route.
Ex: `https://co-ment.glitch.me/api/validate?uid=123userid456&key=789key0123`
The query params `uid` and `key` are checked against those values stored in the user's profile. If they match, the user's `validated` property is set to 'true'.

Refactors 'register' route.
The 'register' route now saves the new user, dispatches a new-user verification email (with a custom URL to the 'validate' route above), and returns a JWT.