### PR TITLE
Changes GET all profiles & posts to only return arrays

### DIFF
--- a/controllers/post.ctrl.js
+++ b/controllers/post.ctrl.js
@@ -37,24 +37,20 @@ function getPosts(req, res) {
 
         query.role = req.query.role;
     }
-
-   // check for 'author_id' & add to query map
+    
+    // check for 'author_id' & add to query map
     if (req.query.hasOwnProperty('author_id')) {
         query.author_id = req.query.author_id;
     }
 
-    Post.find(query, (err, posts) => {
-       if (!posts || !posts.length) {
+    Post.find(query)
+        .exec()
+        .then( posts => res.status(200).json(posts) )
+        .catch( err => {
             return res
-                .status(404)
-                .json({ message : 'No posts found!'});
-        }
-
-        return res
-            .status(200)
-            .json(posts);
-
-    });
+                .status(400)
+                .json({ message: err });
+        });
 }
 
 
@@ -131,7 +127,7 @@ function createPost(req, res) {
             console.log('Error!!!', err);
             return res
                 .status(400)
-                .json({ message: err});
+                .json({ message: err });
         });
 
 }
@@ -208,7 +204,7 @@ function updatePost(req, res) {
         console.log('Error!!!', err);
             return res
                 .status(400)
-                .json({ message: err});
+                .json({ message: err });
     });
 
 }

--- a/controllers/profile.ctrl.js
+++ b/controllers/profile.ctrl.js
@@ -19,19 +19,15 @@ const projection = { signupKey: 0, passwordResetKey: 0, hash: 0, salt: 0 };
 //
 function getProfiles(req, res) {
 
-    User.find({}, projection, (err, profiles) => {
-
-        if (!profiles) {
+    User.find({}, projection)
+        .exec()
+        .then( profiles => res.status(200).json(profiles) )
+        .catch( err => {
             return res
-                .status(404)
-                .json({ message : 'No profiles found!'});
-        }
-
-        return res
-            .status(200)
-            .json(profiles);
-
-    });
+                .status(400)
+                .json({ message: err });
+        });
+    
 }
 
 


### PR DESCRIPTION
Both the GET /api/profiles and GET /api/posts routes return an array of objects if the DB call is successful. And both would return a 'No profiles/posts found' message if no documents were found.

That's bad form, as it results in an unpredictable API. An endpoint should not return a different data type depending on success/failure of a DB call.

This commit changes the 'not found' condition - it now also returns an array (empty in this case).