### PR TITLE
Refactor to support populated author sub-document in posts 

### DIFF
--- a/client/src/containers/ConnectionEmail.jsx
+++ b/client/src/containers/ConnectionEmail.jsx
@@ -51,14 +51,14 @@ class ConnectionEmail extends React.Component {
         // Redux store values
         const connection = {
           mentor: {
-            id: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile._id : this.props.posts.currentPost.author_id ,
-            name: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile.username : this.props.posts.currentPost.author,
-            avatar: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile.avatarUrl : this.props.posts.currentPost.author_avatar,
+            id: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile._id : this.props.posts.currentPost.author._id ,
+            name: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile.username : this.props.posts.currentPost.author.username,
+            avatar: this.props.connectionEmail.role === 'mentor' ? this.props.profiles.userProfile.avatarUrl : this.props.posts.currentPost.author.avatarUrl,
           },
           mentee: {
-            id: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile._id : this.props.posts.currentPost.author_id,
-            name: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile.username : this.props.posts.currentPost.author,
-            avatar: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile.avatarUrl : this.props.posts.currentPost.author_avatar,
+            id: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile._id : this.props.posts.currentPost.author._id,
+            name: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile.username : this.props.posts.currentPost.author.username,
+            avatar: this.props.connectionEmail.role === 'mentee' ? this.props.profiles.userProfile.avatarUrl : this.props.posts.currentPost.author.avatarUrl,
           },
           initiator: {
             id: this.props.appState.userId,

--- a/client/src/containers/PostFull.jsx
+++ b/client/src/containers/PostFull.jsx
@@ -96,7 +96,7 @@ class PostFull extends React.Component {
     if (connections.length > 0) {
       for (let i = 0; i < connections.length; i += 1) {
         if (connections[i].initiator === this.props.appState.userId &&
-          connections[i][this.props.post.role] === this.props.post.author_id) {
+          connections[i][this.props.post.role] === this.props.post.author._id) {
           this.props.actions.setViewPostModalText('You already have a connection to this poster');
           this.props.actions.setViewPostModalClass('modal__show');
           return;
@@ -106,7 +106,7 @@ class PostFull extends React.Component {
       // TODO: go get connections, then test them as above
     }
     this.props.actions.setEmailOptions({
-      recipient: this.props.posts.currentPost.author,
+      recipient: this.props.posts.currentPost.author.username,
       sender: this.props.profiles.userProfile.username,
       subject: `co/ment - Contact Request from ${this.props.profiles.userProfile.username}`,
       body: '',
@@ -133,7 +133,7 @@ class PostFull extends React.Component {
       compress = false;
     }
     const roleText = (post.role === 'mentor' ? 'mentor' : 'mentee');
-    const owner = (this.props.appState.userId === post.author_id);
+    const owner = (this.props.appState.userId === post.author._id);
     const isLiked = this.props.profiles.userProfile.likedPosts.includes(post._id) ?
       'post-full__liked' :
       '';
@@ -232,7 +232,7 @@ class PostFull extends React.Component {
       }
 
     const backgroundStyle = {
-      backgroundImage: `url(${post.author_avatar})`,
+      backgroundImage: `url(${post.author.avatarUrl})`,
       backgroundSize: "cover",
       backgroundPosition: "center center",
     }
@@ -249,7 +249,7 @@ class PostFull extends React.Component {
               <span className="post-full__views">
                 <i className="fa fa-eye" />
                 &nbsp;
-                {this.props.appState.userId === post.author_id ? post.meta.views : post.meta.views + 1}
+                {this.props.appState.userId === post.author._id ? post.meta.views : post.meta.views + 1}
               </span>
               <span className="post-full__likes">
                 <i className="fa fa-heart" />&nbsp;{post.meta.likes}
@@ -277,14 +277,14 @@ class PostFull extends React.Component {
               </div>
               <div className={`post-full__image-wrap`}>
                 <div className={`post-full__image-aspect`}>
-                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author_id}`}>
+                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author._id}`}>
                     <div className={`post-full__image-crop`}>
-                      {post.author_avatar ?
+                      {post.author.avatarUrl ?
                         <div
                           className={`post-full__image`}
                           style={backgroundStyle}
                           role="image"
-                          aria-label={post.author} /> :
+                          aria-label={post.author.username} /> :
                         <i
                           className={`fa fa-user-circle fa-5x post-full__icon--avatar`}
                           aria-hidden="true" />
@@ -293,12 +293,12 @@ class PostFull extends React.Component {
                   </Link>
                 </div>
                 <div className={`post-full__name-wrap`}>
-                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author_id}`}>
+                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author._id}`}>
                     <span className={`post-full__name`}>
-                    {post.author_name}</span>
+                    {post.author.name}</span>
                   </Link>
-                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author_id}`}>
-                      @{post.author}
+                  <Link id="username" className="unstyled-link post-full__username" to={`/viewprofile/${post.author._id}`}>
+                      @{post.author.username}
                 </Link>
                 </div>
               </div>

--- a/client/src/containers/PostThumb.jsx
+++ b/client/src/containers/PostThumb.jsx
@@ -44,7 +44,7 @@ class PostThumb extends React.Component {
       )
     }
     const backgroundStyle = {
-      backgroundImage: `url(${this.props.post.author_avatar})`,
+      backgroundImage: `url(${this.props.post.author.avatarUrl})`,
       backgroundSize: "cover",
       backgroundPosition: "center center",
     }
@@ -82,7 +82,7 @@ class PostThumb extends React.Component {
                   onKeyDown={e => this.handleKeyDown(e, this.props.post)}
                   onClick={
                     () => {
-                      if( this.props.appState.userId !== this.props.post.author_id) {
+                      if( this.props.appState.userId !== this.props.post.author._id) {
                         this.props.api.incrementPostView(this.props.appState.authToken, this.props.post._id);
                         }
                         this.props.openModal(this.props.post);
@@ -110,15 +110,15 @@ class PostThumb extends React.Component {
                     <div className={`post-thumb__image-aspect`}>
                       <Link
                         className="unstyled-link post-thumb__img-link"
-                        to={`/viewprofile/${this.props.post.author_id}`}
+                        to={`/viewprofile/${this.props.post.author._id}`}
                         data-taborder="visual">
                         <div className={`post-thumb__image-crop`}>
-                          {this.props.post.author_avatar ?
+                          {this.props.post.author.avatarUrl ?
                             <div
                               className={`post-thumb__image`}
                               style={backgroundStyle}
                               role="image"
-                              aria-label={this.props.post.author} /> :
+                              aria-label={this.props.post.author.username} /> :
                             <i
                               className={`fa fa-user-circle fa-5x post-thumb__icon--avatar`}
                               aria-hidden="true" />
@@ -129,10 +129,10 @@ class PostThumb extends React.Component {
                     <div className={`post-thumb__name-wrap`}>
                       <Link
                         className="unstyled-link post-thumb__img-link"
-                        to={`/viewprofile/${this.props.post.author_id}`}
+                        to={`/viewprofile/${this.props.post.author._id}`}
                         data-taborder="visual">
                         <span className={`post-thumb__username`}>
-                          @{this.props.post.author}
+                          @{this.props.post.author.username}
                         </span>
                       </Link>
                     </div>
@@ -148,7 +148,7 @@ class PostThumb extends React.Component {
                   onKeyDown={e => this.handleKeyDown(e, this.props.post)}
                   onClick={
                     () => {
-                      if( this.props.appState.userId !== this.props.post.author_id) {
+                      if( this.props.appState.userId !== this.props.post.author._id) {
                         this.props.api.incrementPostView(this.props.appState.authToken, this.props.post._id);
                       }
                       this.props.openModal(this.props.post);

--- a/client/src/containers/PostsGrid.jsx
+++ b/client/src/containers/PostsGrid.jsx
@@ -206,14 +206,14 @@ class PostsGrid extends React.Component {
           <div ref={element => this.element = element} className="flex-row my-shuffle shuffle posts-grid__cont">
             <div className="flex-col-1-sp sizer" />
             {this.props.posts.entries.map((post) => {
-              const languages = post.author_languages ? post.author_languages.map(lang => lang.toLowerCase()) : [];
+              const languages = post.author.languages ? post.author.languages.map(lang => lang.toLowerCase()) : [];
               const keywords = post.keywords ? post.keywords.map(keyword => keyword.toLowerCase()) : [];
-              const gender = post.author_gender ? post.author_gender.toLowerCase() : '';
+              const gender = post.author.gender ? post.author.gender.toLowerCase() : '';
               return (
                 <div
                   key={post._id}
                   className="flex-col-12-xs flex-col-6-md flex-col-4-lg flex-col-3-xl flex-col-2-xxl shuffle-item shuffle-item--visible post"
-                  data-groups={[post.role, gender, post.author_timezone, languages, keywords]}
+                  data-groups={[post.role, gender, post.author.time_zone, languages, keywords]}
                   data-updated={post.updatedAt}
                   data-popular={Number(post.meta.likes) + Number(post.meta.views)}
                 >

--- a/client/src/store/actions/apiActions.js
+++ b/client/src/store/actions/apiActions.js
@@ -1,8 +1,5 @@
 import { CALL_API } from 'redux-api-middleware';
-
-// ENVIRONMENT is a global variable defined by weback.config.js
-// defaults to DEVELOPMENT
-const BASE_URL = (ENVIRONMENT === 'PRODUCTION' ? 'https://co-ment.glitch.me' : 'https://co-ment-dev.glitch.me');
+import { BASE_URL } from './apiConfig.js';
 
 export const SEND_EMAIL_REQUEST = 'SEND_EMAIL_REQUEST';
 export const SEND_EMAIL_SUCCESS = 'SEND_EMAIL_SUCCESS';

--- a/client/src/store/actions/apiConfig.js
+++ b/client/src/store/actions/apiConfig.js
@@ -1,0 +1,17 @@
+/*
+    Defines the base API connection URL
+    Single source of truth used in multiple API actions.
+*/
+
+/* ================================= SETUP ================================= */
+
+const prodUrl = 'https://co-ment.glitch.me';
+//const devUrl  = 'https://co-ment-dev.glitch.me';
+const devUrl  = 'http://127.0.0.1:3001';
+
+
+/* ================================ EXPORTS ================================ */
+
+// ENVIRONMENT is a global variable defined by weback.config.js
+// defaults to DEVELOPMENT
+export const BASE_URL = (ENVIRONMENT === 'PRODUCTION' ? prodUrl : devUrl);

--- a/client/src/store/actions/apiConnectionActions.js
+++ b/client/src/store/actions/apiConnectionActions.js
@@ -1,7 +1,5 @@
 import { CALL_API } from 'redux-api-middleware';
-// ENVIRONMENT is a global variable defined by weback.config.js
-// defaults to DEVELOPMENT
-const BASE_URL = (ENVIRONMENT === 'PRODUCTION' ? 'https://co-ment.glitch.me' : 'https://co-ment-dev.glitch.me');
+import { BASE_URL } from './apiConfig.js';
 
 export const CONNECTION_REQUEST = 'CONNECTION_REQUEST';
 export const CONNECTION_SUCCESS = 'CONNECTION_SUCCESS';

--- a/client/src/store/actions/apiLoginActions.js
+++ b/client/src/store/actions/apiLoginActions.js
@@ -1,7 +1,5 @@
 import { CALL_API } from 'redux-api-middleware';
-// ENVIRONMENT is a global variable defined by weback.config.js
-// defaults to DEVELOPMENT
-const BASE_URL = (ENVIRONMENT === 'PRODUCTION' ? 'https://co-ment.glitch.me' : 'https://co-ment-dev.glitch.me');
+import { BASE_URL } from './apiConfig.js';
 
 export const VALIDATE_TOKEN_REQUEST = 'VALIDATE_TOKEN_REQUEST';
 export const VALIDATE_TOKEN_SUCCESS = 'VALIDATE_TOKEN_SUCCESS';

--- a/client/src/store/actions/apiPostActions.js
+++ b/client/src/store/actions/apiPostActions.js
@@ -1,7 +1,5 @@
 import { CALL_API } from 'redux-api-middleware';
-// ENVIRONMENT is a global variable defined by weback.config.js
-// defaults to DEVELOPMENT
-const BASE_URL = (ENVIRONMENT === 'PRODUCTION' ? 'https://co-ment.glitch.me' : 'https://co-ment-dev.glitch.me');
+import { BASE_URL } from './apiConfig.js';
 
 export const GET_POST_REQUEST = 'GET_POST_REQUEST';
 export const GET_POST_SUCCESS = 'GET_POST_SUCCESS';
@@ -131,7 +129,7 @@ export const INCREMENT_POSTVIEW_FAILURE = 'INCREMENT_POSTVIEW_FAILURE';
 export function incrementPostView(token, postId) {
   return {
     [CALL_API]: {
-      endpoint: `${BASE_URL}/api/postviews/${postId}`,
+      endpoint: `${BASE_URL}/api/posts/${postId}/viewsplusplus`,
       method: 'PUT',
       types: [
         INCREMENT_POSTVIEW_REQUEST,

--- a/client/src/store/reducers/posts.js
+++ b/client/src/store/reducers/posts.js
@@ -25,13 +25,15 @@ const defaultForm = {
 };
 const defaultPost = {
   active: '',
-  author: '',
-  author_id: '',
-  author_name: '',
-  author_avatar: '',
-  author_timezone: '',
-  author_languages: [],
-  author_gender: '',
+  author: {
+      _id: '',
+      username: '',
+      name: '',
+      avatarUrl: '',
+      time_zone: '',
+      languages: [],
+      gender: '',
+  },
   availability: '',
   keywords: [],
   body: '',

--- a/controllers/post.ctrl.js
+++ b/controllers/post.ctrl.js
@@ -14,9 +14,9 @@ const User = require('../models/user');
 //   Example: GET >> /api/posts?role=mentor&id=12345689
 //   Secured: yes, valid JWT required
 //   Query params for filtering requests:
-//     role        Return only 'mentor' or 'mentee' wanted posts
-//     id          Return single specific post object '_id'
-//     author_id   Return only posts by a specific author
+//     role         Return only 'mentor' or 'mentee' wanted posts
+//     id           Return single specific post object '_id'
+//     author       Return only posts by a specific author
 //     active=all   Return all posts, active and inactive
 //   Returns: JSON array of 'post' objects on success.
 //
@@ -40,6 +40,7 @@ function getPosts(req, res) {
     });
 
     Post.find(query)
+        .populate('author', 'username name avatarUrl time_zone languages gender')
         .exec()
         .then( posts => res.status(200).json(posts) )
         .catch( err => {
@@ -54,15 +55,8 @@ function getPosts(req, res) {
 //   Example: POST >> /api/posts
 //   Secured: yes, valid JWT required
 //   Expects:
-//     1) 'author_id' from JWT token
+//     1) author '_id' from JWT token
 //     2) request body properties : {
-//          author              : String
-//          author_id           : String
-//          author_name         : String
-//          author_avatar       : String
-//          author_timezone     : String
-//          author_languages    : Array
-//          author_gemder       : String
 //          role                : String
 //          title               : String
 //          body                : String
@@ -77,10 +71,10 @@ function createPost(req, res) {
     // Check if exists non-deleted post with same author_id, role & title
     Post
         .findOne({
-            author_id : req.token._id,
-            role      : req.body.role,
-            title     : req.body.title,
-            deleted   : false
+            author  : req.token._id,
+            role    : req.body.role,
+            title   : req.body.title,
+            deleted : false
         })
         .exec()
         .then( post => {
@@ -93,36 +87,42 @@ function createPost(req, res) {
                     .json({ message: 'Error - same/similar post already exists!'});
 
             } else {
+                
+                // get a datestamp
+                const now = new Date().toISOString();
 
                 // create new post
                 const myPost = new Post();
 
                 // build new post from request body and token
-                myPost.author           = req.body.author;
-                myPost.author_id        = req.token._id;
-                myPost.author_name      = req.body.author_name;
-                myPost.author_avatar    = req.body.author_avatar;
-                myPost.author_timezone  = req.body.author_timezone;
-                myPost.author_languages = req.body.author_languages;
-                myPost.author_gender    = req.body.author_gender;
+                myPost.author           = req.token._id;
                 myPost.role             = req.body.role;
                 myPost.title            = req.body.title;
                 myPost.body             = req.body.body;
                 myPost.excerpt          = req.body.excerpt;
                 myPost.keywords         = req.body.keywords;
                 myPost.availability     = req.body.availability;
-                myPost.createdAt        = new Date().toISOString();
-                myPost.updatedAt        = new Date().toISOString();
+                myPost.createdAt        = now;
+                myPost.updatedAt        = now;
 
                 // save new post to database
                 myPost.save( (err, newPost) => {
-                    if (err) { throw err; }
+                    if (err) { throw new Error(err); }
 
-                    return res
-                        .status(200)
-                        .json({
-                            message : 'New post saved!',
-                            post    : newPost
+                    newPost
+                        .populate({
+                            path   : 'author',
+                            select : 'username name avatarUrl time_zone languages gender'
+                        }, (err, populatedPost) => {
+
+                            if (err) { throw new Error(err); }
+
+                            return res
+                                .status(200)
+                                .json({
+                                    message : 'New post saved!',
+                                    post    : populatedPost
+                                });
                         });
                 });
 
@@ -143,16 +143,10 @@ function createPost(req, res) {
 //   Example: PUT >> /api/posts/597dd8665229970e99c6ab55
 //   Secured: yes, valid JWT required
 //   Expects:
-//     1) '_id' from JWT token
+//     1) author '_id' from JWT token
 //     2) request body properties : {
 //          action              : Boolean
 //          author              : String
-//          author_id           : String
-//          author_name         : String
-//          author_avatar       : String
-//          author_timezone     : String
-//          author_languages    : Array
-//          author_gender       : String
 //          role                : String
 //          title               : String
 //          body                : String
@@ -167,32 +161,24 @@ function updatePost(req, res) {
     // Target post by post '_id' and 'author_id'.
     // This way, users can only update posts they authored.
     const target = {
-        _id       : req.params.id,
-        author_id : req.token._id
+        _id    : req.params.id,
+        author : req.token._id
     };
 
     // build new post object from request body and parsed token
     const updates = {
-        active           : req.body.active,
-        author           : req.body.author,
-        author_id        : req.token._id,
-        author_name      : req.body.author_name,
-        author_avatar    : req.body.author_avatar,
-        author_timezone  : req.body.author_timezone,
-        author_languages : req.body.author_languages,
-        author_gender    : req.body.author_gender,
-        role             : req.body.role,
-        title            : req.body.title,
-        body             : req.body.body,
-        excerpt          : req.body.excerpt,
-        keywords         : req.body.keywords,
-        availability     : req.body.availability,
-        updatedAt        : new Date().toISOString()
+        active       : req.body.active,
+        author       : req.token._id,
+        role         : req.body.role,
+        title        : req.body.title,
+        body         : req.body.body,
+        excerpt      : req.body.excerpt,
+        keywords     : req.body.keywords,
+        availability : req.body.availability,
+        updatedAt    : new Date().toISOString()
     };
 
-    const options = {
-        new: true  // return the updated document rather than the original
-    };
+    const options = { new: true };
 
     Post.findOneAndUpdate(target, updates, options)
         .exec()
@@ -202,15 +188,23 @@ function updatePost(req, res) {
 
                 return res
                     .status(404)
-                    .json({message: 'Post not found!'});
+                    .json({ message : 'Post not found!' });
 
             } else {
 
-                return res
-                    .status(200)
-                    .json({
-                        message : 'Post updated!',
-                        post    : post
+                post.populate({
+                        path   : 'author',
+                        select : 'username name avatarUrl time_zone languages gender'
+                    }, (err, populatedPost) => {
+
+                        if (err) { throw new Error(err); }
+
+                        return res
+                            .status(200)
+                            .json({
+                                message : 'Post updated!',
+                                post    : populatedPost
+                            });
                     });
 
             }
@@ -229,8 +223,8 @@ function updatePost(req, res) {
 //   Example: DELETE >> /api/posts/597dd8665229970e99c6ab55
 //   Secured: yes, valid JWT required
 //   Expects:
-//     1) '_id' from JWT token
-//     2) 'id' from request params
+//     1) user '_id' from JWT token
+//     2) post 'id' from request params
 //   Returns: success message & deleted post on success
 //
 function deletePost(req, res) {
@@ -238,8 +232,8 @@ function deletePost(req, res) {
     // Target post by post '_id' and post 'author_id'.
     // This way, users can only delete their own posts.
     const target = {
-        _id       : req.params.id,
-        author_id : req.token._id
+        _id    : req.params.id,
+        author : req.token._id
     };
 
     const updates = {
@@ -247,8 +241,10 @@ function deletePost(req, res) {
         active    : false,
         updatedAt : new Date().toISOString()
     };
+    
+    const options = { new : true };
 
-    Post.findOneAndUpdate(target, updates, (err, post) => {
+    Post.findOneAndUpdate(target, updates, options, (err, post) => {
 
         if (err) { throw err; }
 
@@ -260,11 +256,19 @@ function deletePost(req, res) {
 
         } else {
 
-            return res
-                .status(200)
-                .json({
-                    message : 'Post deleted!',
-                    post    : post
+            post.populate({
+                    path   : 'author',
+                    select : 'username name avatarUrl time_zone languages gender'
+                }, (err, populatedPost) => {
+
+                    if (err) { throw new Error(err); }
+
+                    return res
+                        .status(200)
+                        .json({
+                            message : 'Post deleted!',
+                            post    : populatedPost
+                        });
                 });
 
         }
@@ -287,10 +291,10 @@ function incPostViews(req, res) {
     const conditions = {
 
         // the post _id
-        _id       : req.params.id,
+        _id    : req.params.id,
 
         // match only if post author NOT EQUAL to requesting user
-        author_id : { $ne: req.token._id }
+        author : { $ne: req.token._id }
     };
 
     const updates = { $inc: { 'meta.views': 1 } };
@@ -352,7 +356,7 @@ function updatePostLikes(req, res) {
                 .then( post => {
 
                     // fail if author tries to like their own post
-                    if (post.author_id === userId) {
+                    if (post.author === userId) {
                         return res.end();
                     } else if (action === 'plusplus') {
                         post.meta.likes += 1;

--- a/db/index.js
+++ b/db/index.js
@@ -14,7 +14,12 @@ const dbPwd   = process.env.DB_PWD;
 module.exports = {
     
     getDbConnectionString: function() {
-        return `mongodb://${dbUname}:${dbPwd}@ds127983.mlab.com:27983/co-ment`;
+        
+        // live database
+        // return `mongodb://${dbUname}:${dbPwd}@ds127983.mlab.com:27983/co-ment`;
+        
+        // test database
+        return `mongodb://${dbUname}:${dbPwd}@ds161503.mlab.com:61503/co-ment-test`;
     }
     
 };

--- a/models/post.js
+++ b/models/post.js
@@ -13,37 +13,8 @@ const postSchema = new mongoose.Schema({
     },
 
     author : {
-        type     : String,
-        required : true
-    },
-
-    author_id : {
-        type     : String,
-        required : true
-    },
-
-    author_name : {
-        type     : String,
-        required : true
-    },
-
-    author_avatar : {
-        type     : String,
-        required : true
-    },
-
-    author_timezone : {
-        type     : String,
-        required : true
-    },
-
-    author_languages : {
-        type     : [String],  // array of strings
-        required : true       // at least 1 element required
-    },
-
-    author_gender : {
-        type     : String
+        type     : mongoose.Schema.Types.ObjectId,
+		ref      : 'User'
     },
 
     availability : {
@@ -69,6 +40,7 @@ const postSchema = new mongoose.Schema({
 
     role : {
         type     : String,
+        lowercase: true,
         enum     : ['mentor', 'mentee'],
         default  : 'mentee',
         trim     : true


### PR DESCRIPTION
A lot going on in this PR.

The point: to avoid having to maintain detailed post author information in each post record. Instead of saving post author details when creating or updating posts, we now just save the author's `_id` - a reference to their 'User' document in the Users collection in the db. The route controllers populate 'author' fields during queries, adding back the author's details.

*This branch is using localhost (`127.0.0.1`) as API BASE_URL*
*You'll need a running server at `http://127.0.0.1:3001` to use*

Summary of changes:
1.   `db/index.js` - Adds & enables connection string for our test database URI
2.   Refactors all 'post' API route handlers to use Post schema's new nested 'author' property. 'getPosts' now populates 'author' during db query. Create, update, delete now set 'author' with the user '_id' from the JWT token, and return a Post object with populated author on success. Increment and decrement post views & likes now match by 'author' instead of 'author_id'.
3.   `models/post.js` - Refactored to save a ref to the post author's 'User' document.
4.   client files `containers/PostsGrid.js`, `containers/PostFull.js`, `containers/PostThumb.js`, `containers/EditPost.js`, `containers/ConnectionEmail.js` - all references to the old `author_property` are changed to the new `author.property` syntax to match the backend.
5.   `store/reducers/post.js` - Updates default post structure to match backend post schema changes.
6.   Adds `store/actions/apiConfig.js` file to define base API URL based on webpack global ENV variable.
7.   The repeated `BASE_URL` definitions in each of the client `store/actions/api<topic>actions.js` files is replaced by an import statement to the `store/actions/apiConfig.js` file referenced in no. 6 above.
