### PR TITLE
Adds 'refresh_token' route and controller to 'apiRoutes'

### DIFF
--- a/controllers/profile.ctrl.js
+++ b/controllers/profile.ctrl.js
@@ -229,6 +229,50 @@ function deleteProfile(req, res) {
 }
 
 
+// REFRESH USER TOKEN
+//   Example: GET >> /api/refresh_token
+//   Secured: yes, valid JWT required
+//   Expects:
+//     1) '_id' from JWT
+//   Returns: user profile and new JWT on success
+//
+function refreshToken(req, res) {
+    
+    const userId = req.token._id;
+    
+    User.findById(userId)
+        .exec()
+        .then( user => {
+
+            // generate a token
+            const token = user.generateJWT();
+
+            // return the user profile & JWT
+            return res
+                .status(200)
+                .json({
+                    profile : user,
+                    token   : token
+                });
+
+        })
+        .catch( err => {
+            console.log('Error!!!', err);
+                return res
+                    .status(400)
+                    .json({ message: err});
+        });
+
+}
+
+
+
 /* ============================== EXPORT API =============================== */
 
-module.exports = { getProfiles, getOneProfile, updateProfile, deleteProfile };
+module.exports = {
+    getProfiles,
+    getOneProfile,
+    updateProfile,
+    deleteProfile,
+    refreshToken
+};

--- a/routes/apiroutes.js
+++ b/routes/apiroutes.js
@@ -44,6 +44,12 @@ router.use(auth);
 /* ================================ ROUTES ================================= */
 
 
+// Refresh a user's JWT token
+// Used after a user validates their account
+// Returns JSON user profile + new JWT on success
+router.get('/refresh_token', profileCtrl.refreshToken);
+
+
 // Get a user's profile
 // Returns JSON user profile object on success
 router.get('/profile/:id', profileCtrl.getOneProfile);


### PR DESCRIPTION
At some point in this app's history, there was an API enpoint to handle client JWT refreshing. And at some other point in time, that route went away. This commit adds back the route and controller. The route requires a user to have an existing JWT and authenticates them with it. It then generates a new JWT and returns it (and the user's profile) back to the client. Why? Because the `validated` property is encoded in the JWT and users need new JWTs after validating their accounts, so their local JWT includes `validated : true` in its payload. 