### PR TITLE
Refactors engagement util to use mongo aggregation

### DIFF
--- a/utils/engagement.js
+++ b/utils/engagement.js
@@ -112,8 +112,6 @@ function checkAlreadyRun() {
  *  @returns   {Promise}                 Promise w/array of inactive users
 */
 function getInactiveUsers(postAuthors) {
-    
-    console.log(typeof postAuthors[0]);
 
     const projection = {
         _id            : 1,
@@ -132,8 +130,6 @@ function getInactiveUsers(postAuthors) {
 
         // filter for only users who haven't authored posts
         .then( users => users.filter( u => {
-            console.log(u._id.toString(), u.username);
-            console.log(postAuthors.indexOf(u._id.toString()) === -1);
             return postAuthors.indexOf(u._id.toString()) === -1;
         }))
 


### PR DESCRIPTION
Small refactor to use Mongo aggregation pipeline when building array of unique post authors.
Originally, we were getting (`.find()`) all posts and then filtering the result set.
Aggregation pipeline lets us do this all in the DB server, which is more efficient and reduces the amount of code we have to maintain in the client (where the DB's "client" is Node).